### PR TITLE
package.json engines fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "rest-hapi-cli": "./rest-hapi-cli.js"
   },
   "engines": {
-    "node": "6.0.0",
-    "npm": "4.0.5"
+    "node": ">=6.0.0",
+    "npm": ">=4.0.0"
   },
   "directories": {
     "test": "tests"


### PR DESCRIPTION
I had some issues using rest-hapi with yarn, it seems like rest-hapi's package.json requires nodejs to be exactly at version 6.0.0 instead of requiring minimum version of nodejs to be 6.0.0. 
So I just changed this:
```json
  "engines": {
    "node": "6.0.0",
    "npm": "4.0.5"
  }
```
to this:
```json
  "engines": {
    "node": ">=6.0.0",
    "npm": ">=4.0.0"
  }
```