### PR TITLE
CLI fix for windows users when executing rest-hapi-cli command

### DIFF
--- a/rest-hapi-cli.js
+++ b/rest-hapi-cli.js
@@ -6,21 +6,30 @@ var command = userArgs[0];
 
 var exec = require('child_process').exec;
 
+var isWindows = /^win/.test(process.platform);
+
+var cmdString = '$PWD/node_modules/rest-hapi/gulpfile.js';
+
+if (isWindows) {
+	// This will fix the error "No gulpfile found" on windows OS
+	cmdString = './node_modules/rest-hapi/gulpfile.js';
+}
+
 switch (command) {
-    case "seed":
-        exec('gulp seed --gulpfile $PWD/node_modules/rest-hapi/gulpfile.js', function(err, stdout, stderr) {
-            console.log(stdout);
-            console.log(stderr);
-        });
-        break;
-    case "test":
-        exec('gulp test --gulpfile $PWD/node_modules/rest-hapi/gulpfile.js', function(err, stdout, stderr) {
-            console.log(stdout);
-            console.log(stderr);
-        });
-        break;
-    default:
-        console.error("error, unknown command:", command);
-        break;
+	case "seed":
+		exec('gulp seed --gulpfile ' + cmdString, function(err, stdout, stderr) {
+			console.log(stdout);
+			console.log(stderr);
+		});
+		break;
+	case "test":
+		exec('gulp test --gulpfile ' + cmdString, function(err, stdout, stderr) {
+			console.log(stdout);
+			console.log(stderr);
+		});
+		break;
+	default:
+		console.error("error, unknown command:", command);
+		break;
 }
 


### PR DESCRIPTION
This is a fix for windows users who encountered a `No gulpfile found` error when executing `rest-hapi-cli seed`.