### PR TITLE
Clean up tests

### DIFF
--- a/tests/handler-helper-factory.tests.js
+++ b/tests/handler-helper-factory.tests.js
@@ -52,7 +52,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -90,7 +90,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub,
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -134,7 +134,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var postDeferred = Q.defer();
@@ -193,7 +193,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub,
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -240,7 +240,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub,
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -289,7 +289,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var postDeferred = Q.defer();
@@ -347,7 +347,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -393,7 +393,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -444,7 +444,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -484,7 +484,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub,
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -526,7 +526,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var postDeferred = Q.defer();
@@ -583,7 +583,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub,
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -632,7 +632,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var postDeferred = Q.defer();
@@ -689,7 +689,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var postDeferred = Q.defer();
@@ -747,7 +747,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -793,7 +793,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -844,7 +844,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var preDeferred = Q.defer();
@@ -896,7 +896,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -941,7 +941,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -984,7 +984,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -1029,7 +1029,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var deferred = Q.defer();
@@ -1082,7 +1082,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -1129,7 +1129,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -1183,7 +1183,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -1236,7 +1236,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -1288,7 +1288,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -1341,7 +1341,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var preDeferred = Q.defer();
@@ -1391,7 +1391,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -1432,7 +1432,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var deferred = Q.defer();
@@ -1481,7 +1481,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -1524,7 +1524,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -1574,7 +1574,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -1620,7 +1620,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -1672,7 +1672,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -1727,7 +1727,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var preDeferred = Q.defer();
@@ -1779,7 +1779,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -1824,7 +1824,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -1867,7 +1867,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -1912,7 +1912,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       var deferred = Q.defer();
@@ -1965,7 +1965,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2012,7 +2012,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -2066,7 +2066,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2112,7 +2112,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2158,7 +2158,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -2210,7 +2210,7 @@ var extend = require('util')._extend;
 //         './query-helper': queryHelperStub,
 //         'boom': boomStub
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -2263,7 +2263,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2311,7 +2311,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("setAssociation", setAssociation);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2361,7 +2361,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("setAssociation", setAssociation);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2414,7 +2414,7 @@ var extend = require('util')._extend;
 //       handlerHelperFactory.__set__("setAssociation", setAssociation);
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2465,7 +2465,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2516,7 +2516,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2571,7 +2571,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2619,7 +2619,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("removeAssociation", removeAssociation);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2669,7 +2669,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("removeAssociation", removeAssociation);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2722,7 +2722,7 @@ var extend = require('util')._extend;
 //       handlerHelperFactory.__set__("removeAssociation", removeAssociation);
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2773,7 +2773,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2824,7 +2824,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2879,7 +2879,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2926,7 +2926,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("setAssociation", setAssociation);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -2979,7 +2979,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("setAssociation", setAssociation);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3033,7 +3033,7 @@ var extend = require('util')._extend;
 //       handlerHelperFactory.__set__("setAssociation", setAssociation);
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3085,7 +3085,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3137,7 +3137,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3193,7 +3193,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3249,7 +3249,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = proxyquire('../utilities/handler-helper-factory', {
 //         './query-helper': queryHelperStub,
 //       })(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3312,7 +3312,7 @@ var extend = require('util')._extend;
 //       handlerHelperFactory.__set__("QueryHelper", queryHelperStub);
 //       handlerHelperFactory.__set__("generateListHandler", handlerSpy2);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3387,7 +3387,7 @@ var extend = require('util')._extend;
 //       handlerHelperFactory.__set__("QueryHelper", queryHelperStub);
 //       handlerHelperFactory.__set__("generateListHandler", handlerSpy2);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3463,7 +3463,7 @@ var extend = require('util')._extend;
 //       handlerHelperFactory.__set__("QueryHelper", queryHelperStub);
 //       handlerHelperFactory.__set__("generateListHandler", handlerSpy2);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3526,7 +3526,7 @@ var extend = require('util')._extend;
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       handlerHelperFactory.__set__("Boom", boomStub);
 //       handlerHelperFactory = handlerHelperFactory(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3591,7 +3591,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       var setAssociation = handlerHelperFactory.__get__("setAssociation");
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3650,7 +3650,7 @@ var extend = require('util')._extend;
 //       var deferredSpy = { resolve: sandbox.spy(function(){ deferred.resolve() }) };
 //       Qstub.defer = function(){ return deferredSpy };
 //       handlerHelperFactory.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3724,7 +3724,7 @@ var extend = require('util')._extend;
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelperFactory.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3813,7 +3813,7 @@ var extend = require('util')._extend;
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelperFactory.__set__("Q", Qstub);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3902,7 +3902,7 @@ var extend = require('util')._extend;
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelperFactory.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3987,7 +3987,7 @@ var extend = require('util')._extend;
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelperFactory.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4072,7 +4072,7 @@ var extend = require('util')._extend;
 //       var server = sandbox.spy();
 //       var handlerHelperFactory = rewire('../utilities/handler-helper-factory');
 //       var removeAssociation = handlerHelperFactory.__get__("removeAssociation");
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4131,7 +4131,7 @@ var extend = require('util')._extend;
 //       var deferredSpy = { resolve: sandbox.spy(function(){ deferred.resolve() }) };
 //       Qstub.defer = function(){ return deferredSpy };
 //       handlerHelperFactory.__set__("Q", Qstub);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4217,7 +4217,7 @@ var extend = require('util')._extend;
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelperFactory.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4304,7 +4304,7 @@ var extend = require('util')._extend;
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelperFactory.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4389,7 +4389,7 @@ var extend = require('util')._extend;
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelperFactory.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {

--- a/tests/handler-helper.tests.js
+++ b/tests/handler-helper.tests.js
@@ -221,7 +221,8 @@ test('handler-helper.listHandler', function (t) {
           };
           var paginateDeferred = Q.defer();
           var paginateSpy = sandbox.spy(function () {
-            paginateDeferred.resolve()
+            paginateDeferred.resolve();
+            return { exec: function(){ return Q.when([]) } };
           });
           queryHelperStub.paginate = paginateSpy;
           var errorHelperStub = sandbox.stub(require('../utilities/error-helper'));
@@ -287,7 +288,8 @@ test('handler-helper.listHandler', function (t) {
           };
           var deferred = Q.defer();
           var execSpy = sandbox.spy(function () {
-            deferred.resolve()
+            deferred.resolve();
+            return Q.when([]);
           });
           var paginateSpy = sandbox.spy(function () {
             return {exec: execSpy}

--- a/tests/handler-helper.tests.js
+++ b/tests/handler-helper.tests.js
@@ -656,10 +656,8 @@ test('handler-helper.listHandler', function (t) {
           });
           queryHelperStub.paginate = paginateSpy;
 
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function () {
           });
@@ -737,10 +735,8 @@ test('handler-helper.listHandler', function (t) {
           });
           queryHelperStub.paginate = paginateSpy;
 
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function () {
           });
@@ -781,10 +777,8 @@ test('handler-helper.listHandler', function (t) {
           var Log = logger.bind("handler-helper");
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function () {
           });
@@ -832,10 +826,8 @@ test('handler-helper.listHandler', function (t) {
           var Log = logger.bind("handler-helper");
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function () {
           });
@@ -1181,10 +1173,8 @@ test('handler-helper.findHandler', function(t) {
             return mongooseQuery2;
           };
 
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -1252,10 +1242,8 @@ test('handler-helper.findHandler', function(t) {
             return mongooseQuery2;
           };
 
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -1310,10 +1298,8 @@ test('handler-helper.findHandler', function(t) {
             return mongooseQuery2;
           };
 
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -1355,10 +1341,8 @@ test('handler-helper.findHandler', function(t) {
           var Log = logger.bind("handler-helper");
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -1407,10 +1391,8 @@ test('handler-helper.findHandler', function(t) {
           var Log = logger.bind("handler-helper");
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -1861,10 +1843,8 @@ test('handler-helper.createHandler', function(t) {
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createAttributesFilter = function(){ return "attributes" };
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -1930,10 +1910,8 @@ test('handler-helper.createHandler', function(t) {
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createAttributesFilter = function(){ return "attributes" };
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -1999,10 +1977,8 @@ test('handler-helper.createHandler', function(t) {
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createAttributesFilter = function(){ return "attributes" };
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2050,10 +2026,8 @@ test('handler-helper.createHandler', function(t) {
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createAttributesFilter = function(){ return "attributes" };
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2281,9 +2255,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var sandbox = sinon.sandbox.create();
           var Log = logger.bind("handler-helper");
           var server = sandbox.spy();
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            'boom': boomStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2330,9 +2302,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var sandbox = sinon.sandbox.create();
           var Log = logger.bind("handler-helper");
           var server = sandbox.spy();
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            'boom': boomStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2372,9 +2342,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var sandbox = sinon.sandbox.create();
           var Log = logger.bind("handler-helper");
           var server = sandbox.spy();
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            'boom': boomStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2420,9 +2388,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var sandbox = sinon.sandbox.create();
           var Log = logger.bind("handler-helper");
           var server = sandbox.spy();
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            'boom': boomStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2778,10 +2744,8 @@ test('handler-helper.updateHandler', function(t) {
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createAttributesFilter = function(){ return "attributes" };
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2837,10 +2801,8 @@ test('handler-helper.updateHandler', function(t) {
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createAttributesFilter = function(){ return "attributes" };
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2882,10 +2844,8 @@ test('handler-helper.updateHandler', function(t) {
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createAttributesFilter = function(){ return "attributes" };
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2927,10 +2887,8 @@ test('handler-helper.updateHandler', function(t) {
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createAttributesFilter = function(){ return "attributes" };
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 
@@ -2978,10 +2936,8 @@ test('handler-helper.updateHandler', function(t) {
           var server = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createAttributesFilter = function(){ return "attributes" };
-          var boomStub = sandbox.stub(require('boom'));
           var handlerHelper = proxyquire('../utilities/handler-helper', {
-            './query-helper': queryHelperStub,
-            'boom': boomStub
+            './query-helper': queryHelperStub
           });
           sandbox.stub(Log, 'error', function(){});
 

--- a/tests/handler-helper.tests.js
+++ b/tests/handler-helper.tests.js
@@ -65,7 +65,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          // sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -108,7 +108,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          // sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -164,7 +164,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          // sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -229,7 +229,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          // sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -243,15 +243,13 @@ test('handler-helper.listHandler', function (t) {
           var request = { query: query };
           //</editor-fold>
 
-          var LogStub = sandbox.stub(Log, 'error', function () {
-          });
           //<editor-fold desc="Act">
-          handlerHelper.listHandler(userModel, request, LogStub);
+          handlerHelper.listHandler(userModel, request, Log);
           //</editor-fold>
 
           //<editor-fold desc="Assert">
           return paginateDeferred.promise.then(function () {
-            t.ok(queryHelperStub.paginate.calledWithExactly(query, mongooseQuery1, LogStub), "paginate called");
+            t.ok(queryHelperStub.paginate.calledWithExactly(query, mongooseQuery1, Log), "paginate called");
           })
           //</editor-fold>
 
@@ -300,7 +298,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -350,7 +348,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          // sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var preDeferred = Q.defer();
@@ -430,7 +428,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          // sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var postDeferred = Q.defer();
@@ -511,8 +509,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function () {
-          });
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -582,8 +579,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function () {
-          });
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -659,8 +655,7 @@ test('handler-helper.listHandler', function (t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function () {
-          });
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var postDeferred = Q.defer();
@@ -738,8 +733,7 @@ test('handler-helper.listHandler', function (t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function () {
-          });
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -780,8 +774,7 @@ test('handler-helper.listHandler', function (t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function () {
-          });
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -829,8 +822,7 @@ test('handler-helper.listHandler', function (t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function () {
-          });
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -886,7 +878,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -931,7 +923,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -979,7 +971,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var preDeferred = Q.defer();
@@ -1048,7 +1040,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var deferred = Q.defer();
@@ -1118,7 +1110,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -1176,7 +1168,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var postDeferred = Q.defer();
@@ -1245,7 +1237,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var userModel = mongoose.model("user", userSchema);
@@ -1301,7 +1293,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -1344,7 +1336,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -1394,7 +1386,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -1452,7 +1444,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var preDeferred = Q.defer();
@@ -1507,7 +1499,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -1559,7 +1551,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -1605,7 +1597,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -1654,7 +1646,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          // sandbox.stub(Log, 'error', function(){});
+          // sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var deferred = Q.defer();
@@ -1722,7 +1714,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -1784,7 +1776,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -1846,7 +1838,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -1913,7 +1905,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -1980,7 +1972,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2029,7 +2021,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2081,7 +2073,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var preDeferred = Q.defer();
@@ -2130,7 +2122,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -2170,7 +2162,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var deferred = Q.defer();
@@ -2218,7 +2210,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -2257,7 +2249,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2304,7 +2296,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -2344,7 +2336,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2390,7 +2382,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2446,7 +2438,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var preDeferred = Q.defer();
@@ -2499,7 +2491,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -2547,7 +2539,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -2594,7 +2586,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -2639,7 +2631,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           var deferred = Q.defer();
@@ -2698,7 +2690,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -2747,7 +2739,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2804,7 +2796,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -2847,7 +2839,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
 
@@ -2890,7 +2882,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2939,7 +2931,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error', function(){});
+          sandbox.stub(Log, 'error').callsFake(function(){})
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2991,7 +2983,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //       });
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3039,7 +3031,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3089,7 +3081,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3142,7 +3134,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3193,7 +3185,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3244,7 +3236,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3299,7 +3291,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //       });
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3347,7 +3339,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("removeAssociation", removeAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3397,7 +3389,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("removeAssociation", removeAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3450,7 +3442,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("removeAssociation", removeAssociation);
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3501,7 +3493,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3552,7 +3544,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3607,7 +3599,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //       });
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3654,7 +3646,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3707,7 +3699,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3761,7 +3753,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3813,7 +3805,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3865,7 +3857,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3921,7 +3913,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //       });
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -3977,7 +3969,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //         './query-helper': queryHelperStub,
 //       });
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4040,7 +4032,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("QueryHelper", queryHelperStub);
 //       handlerHelper.__set__("list", handlerSpy2);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4115,7 +4107,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("QueryHelper", queryHelperStub);
 //       handlerHelper.__set__("list", handlerSpy2);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4191,7 +4183,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("QueryHelper", queryHelperStub);
 //       handlerHelper.__set__("list", handlerSpy2);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4254,7 +4246,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4319,7 +4311,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       var setAssociation = handlerHelper.__get__("setAssociation");
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4378,7 +4370,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var deferredSpy = { resolve: sandbox.spy(function(){ deferred.resolve() }) };
 //       Qstub.defer = function(){ return deferredSpy };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4452,7 +4444,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4541,7 +4533,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4630,7 +4622,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4715,7 +4707,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4800,7 +4792,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       var removeAssociation = handlerHelper.__get__("removeAssociation");
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4859,7 +4851,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var deferredSpy = { resolve: sandbox.spy(function(){ deferred.resolve() }) };
 //       Qstub.defer = function(){ return deferredSpy };
 //       handlerHelper.__set__("Q", Qstub);
-//       sandbox.stub(Log, 'error', function(){});
+//       sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4945,7 +4937,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5032,7 +5024,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5117,7 +5109,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error', function(){});
+//       // sandbox.stub(Log, 'error').callsFake(function(){})
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {

--- a/tests/joi-mongoose-helper.tests.js
+++ b/tests/joi-mongoose-helper.tests.js
@@ -41,7 +41,7 @@ test('joi-mongoose-helper.generateJoiReadModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -79,7 +79,7 @@ test('joi-mongoose-helper.generateJoiReadModel', function (t) {
 
     t.plan(3);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -119,7 +119,7 @@ test('joi-mongoose-helper.generateJoiReadModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -163,7 +163,7 @@ test('joi-mongoose-helper.generateJoiReadModel', function (t) {
 
     t.plan(4);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -210,7 +210,7 @@ test('joi-mongoose-helper.generateJoiReadModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -248,7 +248,7 @@ test('joi-mongoose-helper.generateJoiReadModel', function (t) {
 
     t.plan(16);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -316,7 +316,7 @@ test('joi-mongoose-helper.generateJoiReadModel', function (t) {
 
     t.plan(1);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -355,7 +355,7 @@ test('joi-mongoose-helper.generateJoiUpdateModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -393,7 +393,7 @@ test('joi-mongoose-helper.generateJoiUpdateModel', function (t) {
 
     t.plan(3);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -433,7 +433,7 @@ test('joi-mongoose-helper.generateJoiUpdateModel', function (t) {
 
     t.plan(1);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -471,7 +471,7 @@ test('joi-mongoose-helper.generateJoiUpdateModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -513,7 +513,7 @@ test('joi-mongoose-helper.generateJoiUpdateModel', function (t) {
 
     t.plan(3);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -555,7 +555,7 @@ test('joi-mongoose-helper.generateJoiUpdateModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -593,7 +593,7 @@ test('joi-mongoose-helper.generateJoiUpdateModel', function (t) {
 
     t.plan(8);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any().only("test")
     });
 
@@ -700,7 +700,7 @@ test('joi-mongoose-helper.generateJoiCreateModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -738,7 +738,7 @@ test('joi-mongoose-helper.generateJoiCreateModel', function (t) {
 
     t.plan(3);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -778,7 +778,7 @@ test('joi-mongoose-helper.generateJoiCreateModel', function (t) {
 
     t.plan(1);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -816,7 +816,7 @@ test('joi-mongoose-helper.generateJoiCreateModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -858,7 +858,7 @@ test('joi-mongoose-helper.generateJoiCreateModel', function (t) {
 
     t.plan(3);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -900,7 +900,7 @@ test('joi-mongoose-helper.generateJoiCreateModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -938,7 +938,7 @@ test('joi-mongoose-helper.generateJoiCreateModel', function (t) {
 
     t.plan(8);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any().only("test")
     });
 
@@ -1042,7 +1042,7 @@ test('joi-mongoose-helper.generateJoiAssociationModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -1078,7 +1078,7 @@ test('joi-mongoose-helper.generateJoiAssociationModel', function (t) {
 
     t.plan(3);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -1115,7 +1115,7 @@ test('joi-mongoose-helper.generateJoiAssociationModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 
@@ -1149,7 +1149,7 @@ test('joi-mongoose-helper.generateJoiAssociationModel', function (t) {
 
     t.plan(2);
 
-    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType", function () {
+    sinon.stub(joiMongooseHelper, "generateJoiModelFromFieldType").callsFake(function () {
       return Joi.any()
     });
 

--- a/tests/query-helper.tests.js
+++ b/tests/query-helper.tests.js
@@ -379,7 +379,7 @@ test('query-helper.getSortableFields', function (t) {
 
     t.plan(1);
 
-    sinon.stub(queryHelper, "getReadableFields", function () {
+    sinon.stub(queryHelper, "getReadableFields").callsFake(function () {
       return []
     });
 
@@ -410,7 +410,7 @@ test('query-helper.getSortableFields', function (t) {
 
     t.plan(1);
 
-    sinon.stub(queryHelper, "getReadableFields", function () {
+    sinon.stub(queryHelper, "getReadableFields").callsFake(function () {
       return ["email", "firstName", "lastName"]
     });
 
@@ -636,7 +636,7 @@ test('query-helper.populateEmbeddedDocs', function (t) {
     //<editor-fold desc="Arrange">
     var queryHelper = rewire('../utilities/query-helper');
 
-    sinon.stub(queryHelper, "createAttributesFilter", sinon.spy());
+    sinon.stub(queryHelper, "createAttributesFilter").callsFake(sinon.spy());
 
     var nestPopulate = queryHelper.__get__("nestPopulate");
 
@@ -679,7 +679,7 @@ test('query-helper.populateEmbeddedDocs', function (t) {
     //<editor-fold desc="Arrange">
     var queryHelper = rewire('../utilities/query-helper');
 
-    sinon.stub(queryHelper, "createAttributesFilter", sinon.spy());
+    sinon.stub(queryHelper, "createAttributesFilter").callsFake(sinon.spy());
 
     var nestPopulate = queryHelper.__get__("nestPopulate");
 
@@ -716,7 +716,7 @@ test('query-helper.populateEmbeddedDocs', function (t) {
     //<editor-fold desc="Arrange">
     var queryHelper = rewire('../utilities/query-helper');
 
-    sinon.stub(queryHelper, "createAttributesFilter", sinon.spy());
+    sinon.stub(queryHelper, "createAttributesFilter").callsFake(sinon.spy());
 
     var nestPopulate = queryHelper.__get__("nestPopulate");
 
@@ -770,7 +770,7 @@ test('query-helper.populateEmbeddedDocs', function (t) {
     var createAttributesFilter = sinon.stub();
     createAttributesFilter.returns("test");
 
-    sinon.stub(queryHelper, "createAttributesFilter", createAttributesFilter);
+    sinon.stub(queryHelper, "createAttributesFilter").callsFake(createAttributesFilter);
 
     var nestPopulate = queryHelper.__get__("nestPopulate");
 
@@ -1108,13 +1108,13 @@ test('query-helper.createMongooseQuery', function (t) {
       select: sinon.spy(),
       where: sinon.spy()
     };
-    sinon.stub(queryHelper, "createAttributesFilter", function () {
+    sinon.stub(queryHelper, "createAttributesFilter").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "populateEmbeddedDocs", function () {
+    sinon.stub(queryHelper, "populateEmbeddedDocs").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "setSort", function () {
+    sinon.stub(queryHelper, "setSort").callsFake(function () {
       return mongooseQuery
     });
 
@@ -1174,19 +1174,19 @@ test('query-helper.createMongooseQuery', function (t) {
       select: sinon.spy(),
       where: sinon.spy()
     };
-    sinon.stub(queryHelper, "setSkip", function () {
+    sinon.stub(queryHelper, "setSkip").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "setLimit", function () {
+    sinon.stub(queryHelper, "setLimit").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "createAttributesFilter", function () {
+    sinon.stub(queryHelper, "createAttributesFilter").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "populateEmbeddedDocs", function () {
+    sinon.stub(queryHelper, "populateEmbeddedDocs").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "setSort", function () {
+    sinon.stub(queryHelper, "setSort").callsFake(function () {
       return mongooseQuery
     });
 
@@ -1233,19 +1233,19 @@ test('query-helper.createMongooseQuery', function (t) {
       select: sinon.spy(),
       where: sinon.spy()
     };
-    sinon.stub(queryHelper, "setSkip", function () {
+    sinon.stub(queryHelper, "setSkip").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "setLimit", function () {
+    sinon.stub(queryHelper, "setLimit").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "createAttributesFilter", function () {
+    sinon.stub(queryHelper, "createAttributesFilter").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "populateEmbeddedDocs", function () {
+    sinon.stub(queryHelper, "populateEmbeddedDocs").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "setSort", function () {
+    sinon.stub(queryHelper, "setSort").callsFake(function () {
       return mongooseQuery
     });
 
@@ -1310,13 +1310,13 @@ test('query-helper.paginate', function (t) {
       select: sinon.spy(),
       where: sinon.spy()
     };
-    sinon.stub(queryHelper, "setLimit", function () {
+    sinon.stub(queryHelper, "setLimit").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "setSkip", function () {
+    sinon.stub(queryHelper, "setSkip").callsFake(function () {
       return mongooseQuery
     });
-    sinon.stub(queryHelper, "setPage", function () {
+    sinon.stub(queryHelper, "setPage").callsFake(function () {
       return mongooseQuery
     });
 

--- a/tests/rest-helper-factory.tests.js
+++ b/tests/rest-helper-factory.tests.js
@@ -130,9 +130,8 @@ test('rest-helper-factory.defaultHeadersValidation', function (t) {
 
 test('rest-helper-factory.generateRoutes', function (t) {
   var server = sinon.spy();
-  sinon.stub(Log, 'error', function () {
-  });
-  sinon.stub(Log, 'bind', function () {
+  sinon.stub(Log, 'error').callsFake(function(){});
+  sinon.stub(Log, 'bind').callsFake(function(){
     return Log
   });
   var restHelperFactory = require('../utilities/rest-helper-factory')(Log, mongoose, server);
@@ -153,12 +152,12 @@ test('rest-helper-factory.generateRoutes', function (t) {
     };
     var userModel = mongoose.model("user", userSchema);
 
-    sinon.stub(restHelperFactory, 'generateListEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateFindEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateCreateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateUpdateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint', sinon.spy());
+    sinon.stub(restHelperFactory, 'generateListEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateFindEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateCreateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateUpdateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint').callsFake(sinon.spy());
     //</editor-fold>
 
     //<editor-fold desc="Act">
@@ -204,12 +203,12 @@ test('rest-helper-factory.generateRoutes', function (t) {
     };
     var userModel = mongoose.model("user", userSchema);
 
-    sinon.stub(restHelperFactory, 'generateListEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateFindEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateCreateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateUpdateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint', sinon.spy());
+    sinon.stub(restHelperFactory, 'generateListEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateFindEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateCreateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateUpdateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint').callsFake(sinon.spy());
     //</editor-fold>
 
     //<editor-fold desc="Act">
@@ -269,18 +268,18 @@ test('rest-helper-factory.generateRoutes', function (t) {
     var groups = userModel.routeOptions.associations.groups;
     var permissions = userModel.routeOptions.associations.permissions;
 
-    sinon.stub(restHelperFactory, 'generateListEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateFindEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateCreateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateUpdateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint', sinon.spy());
+    sinon.stub(restHelperFactory, 'generateListEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateFindEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateCreateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateUpdateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint').callsFake(sinon.spy());
 
-    sinon.stub(restHelperFactory, 'generateAssociationAddOneEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateAssociationRemoveOneEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateAssociationAddManyEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateAssociationRemoveManyEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateAssociationGetAllEndpoint', sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationAddOneEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationRemoveOneEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationAddManyEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationRemoveManyEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationGetAllEndpoint').callsFake(sinon.spy());
     //</editor-fold>
 
     //<editor-fold desc="Act">
@@ -351,18 +350,18 @@ test('rest-helper-factory.generateRoutes', function (t) {
     };
     var userModel = mongoose.model("user", userSchema);
 
-    sinon.stub(restHelperFactory, 'generateListEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateFindEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateCreateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateUpdateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint', sinon.spy());
+    sinon.stub(restHelperFactory, 'generateListEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateFindEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateCreateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateUpdateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint').callsFake(sinon.spy());
 
-    sinon.stub(restHelperFactory, 'generateAssociationAddOneEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateAssociationRemoveOneEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateAssociationAddManyEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateAssociationRemoveManyEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateAssociationGetAllEndpoint', sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationAddOneEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationRemoveOneEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationAddManyEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationRemoveManyEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateAssociationGetAllEndpoint').callsFake(sinon.spy());
     //</editor-fold>
 
     //<editor-fold desc="Act">
@@ -415,12 +414,12 @@ test('rest-helper-factory.generateRoutes', function (t) {
     var userModel = mongoose.model("user", userSchema);
     var extraEndpoints = userModel.routeOptions.extraEndpoints;
 
-    sinon.stub(restHelperFactory, 'generateListEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateFindEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateCreateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateUpdateEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint', sinon.spy());
-    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint', sinon.spy());
+    sinon.stub(restHelperFactory, 'generateListEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateFindEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateCreateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateUpdateEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteOneEndpoint').callsFake(sinon.spy());
+    sinon.stub(restHelperFactory, 'generateDeleteManyEndpoint').callsFake(sinon.spy());
     //</editor-fold>
 
     //<editor-fold desc="Act">
@@ -463,7 +462,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -506,7 +505,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -551,7 +550,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -594,7 +593,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -637,7 +636,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -682,7 +681,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -743,7 +742,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -788,7 +787,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -835,7 +834,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -894,7 +893,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -954,7 +953,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     queryHelperStub.getSortableFields = this.spy(function () {
       return sortableFields
     });
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiModelFromFieldType = this.spy(function () {
@@ -1062,7 +1061,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     queryHelperStub.getSortableFields = this.spy(function () {
       return sortableFields
     });
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1135,7 +1134,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -1190,7 +1189,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1240,7 +1239,7 @@ test('rest-helper-factory.generateListEndpoint', function (t) {
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
     var readModel = Joi.any().valid(["test"]);
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return readModel
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1303,7 +1302,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1346,7 +1345,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1389,7 +1388,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1432,7 +1431,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1475,7 +1474,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1520,7 +1519,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1581,7 +1580,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1626,7 +1625,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -1673,7 +1672,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1732,7 +1731,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1792,7 +1791,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     queryHelperStub.getSortableFields = this.spy(function () {
       return sortableFields
     });
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1853,7 +1852,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     queryHelperStub.getSortableFields = this.spy(function () {
       return sortableFields
     });
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -1917,7 +1916,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var joiStub = require('joi');
@@ -1978,7 +1977,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -2029,7 +2028,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -2075,7 +2074,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
     var readModel = Joi.any().valid(["test"]);
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return readModel
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -2127,7 +2126,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2165,7 +2164,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2203,7 +2202,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiCreateModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiCreateModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiReadModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2241,7 +2240,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2279,7 +2278,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2319,7 +2318,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel =function(){return Joi.any()};
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2373,7 +2372,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2413,7 +2412,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var config = { authStrategy: "TEST_AUTH" };
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -2455,7 +2454,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2509,7 +2508,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2553,7 +2552,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = function(){return Joi.any().valid("TEST")};
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2592,7 +2591,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var config = { authStrategy: "TEST_AUTH" };
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -2638,7 +2637,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     var handlerHelperStubWrapper = this.stub();
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return Joi.any()});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return Joi.any()});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2679,7 +2678,7 @@ test('rest-helper-factory.generateFindEndpoint', function (t) {
 //     handlerHelperStubWrapper.returns(handlerHelperStub);
 //     var queryHelperStub = this.stub(require('../utilities/query-helper'));
 //     var readModel = Joi.any().valid(["test"]);
-//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function(){return readModel});
+//     var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function(){return readModel});
 //     joiMongooseHelperStub.generateJoiCreateModel = this.spy(function(){return Joi.any()});
 //     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
 //       './handler-helper-factory': handlerHelperStubWrapper,
@@ -2732,7 +2731,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -2775,7 +2774,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -2818,7 +2817,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -2863,7 +2862,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -2924,7 +2923,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -2969,7 +2968,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -3016,7 +3015,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -3075,7 +3074,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -3124,7 +3123,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var joiStub = require('joi');
@@ -3190,7 +3189,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -3241,7 +3240,7 @@ test('rest-helper-factory.generateDeleteOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -3294,7 +3293,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3343,7 +3342,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3389,7 +3388,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3435,7 +3434,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3481,7 +3480,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3529,7 +3528,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3596,7 +3595,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3644,7 +3643,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3694,7 +3693,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3756,7 +3755,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3808,7 +3807,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3858,7 +3857,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3923,7 +3922,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -3977,7 +3976,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -4026,7 +4025,7 @@ test('rest-helper-factory.generateUpdateEndpoint', function (t) {
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
     var readModel = Joi.any().valid(["test"]);
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return readModel
     });
     joiMongooseHelperStub.generateJoiUpdateModel = this.spy(function () {
@@ -4084,7 +4083,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4137,7 +4136,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4192,7 +4191,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4242,7 +4241,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4292,7 +4291,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4344,7 +4343,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = function () {
@@ -4417,7 +4416,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4469,7 +4468,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -4523,7 +4522,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4614,7 +4613,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4670,7 +4669,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiAssociationModel = function () {
@@ -4737,7 +4736,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var joiStub = require('joi');
@@ -4806,7 +4805,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -4864,7 +4863,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4916,7 +4915,7 @@ test('rest-helper-factory.generateAssociationAddOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiAssociationModel').callsFake(function () {
       return readModel
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -4978,7 +4977,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5031,7 +5030,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5086,7 +5085,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5136,7 +5135,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5186,7 +5185,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5238,7 +5237,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = function () {
@@ -5311,7 +5310,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5363,7 +5362,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -5417,7 +5416,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5507,7 +5506,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5563,7 +5562,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var joiStub = require('joi');
@@ -5632,7 +5631,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -5690,7 +5689,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5742,7 +5741,7 @@ test('rest-helper-factory.generateAssociationRemoveOneEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return readModel
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5804,7 +5803,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5857,7 +5856,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5912,7 +5911,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -5962,7 +5961,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6012,7 +6011,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6063,7 +6062,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = function () {
@@ -6135,7 +6134,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6187,7 +6186,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -6241,7 +6240,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6309,7 +6308,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6365,7 +6364,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiAssociationModel = function () {
@@ -6445,7 +6444,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var joiStub = require('joi');
@@ -6512,7 +6511,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -6570,7 +6569,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6622,7 +6621,7 @@ test('rest-helper-factory.generateAssociationAddManyEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return readModel
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6684,7 +6683,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6737,7 +6736,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6792,7 +6791,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6845,7 +6844,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6900,7 +6899,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -6953,7 +6952,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -7006,7 +7005,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -7061,7 +7060,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiUpdateModel = function () {
@@ -7138,7 +7137,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -7195,7 +7194,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -7252,7 +7251,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -7325,7 +7324,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -7395,7 +7394,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     queryHelperStub.getSortableFields = this.spy(function () {
       return sortableFields
     });
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     joiMongooseHelperStub.generateJoiModelFromFieldType = this.spy(function () {
@@ -7508,7 +7507,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     queryHelperStub.getSortableFields = this.spy(function () {
       return sortableFields
     });
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -7599,7 +7598,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var config = {authStrategy: "TEST_AUTH"};
@@ -7660,7 +7659,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     var handlerHelperStubWrapper = this.stub();
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return Joi.any()
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {
@@ -7716,7 +7715,7 @@ test('rest-helper-factory.generateAssociationGetAllEndpoint', function (t) {
     handlerHelperStubWrapper.returns(handlerHelperStub);
     var queryHelperStub = this.stub(require('../utilities/query-helper'));
     var readModel = Joi.any().valid(["test"]);
-    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel', function () {
+    var joiMongooseHelperStub = this.stub(require('../utilities/joi-mongoose-helper'), 'generateJoiReadModel').callsFake(function () {
       return readModel
     });
     var restHelperFactory = proxyquire('../utilities/rest-helper-factory', {


### PR DESCRIPTION
Use new sinon stub API `stub(obj, 'meth').callsFake(fn)` to avoid deprecation warning: `stub(obj, 'meth', fn)` is deprecated in v2 and removed in v3.

Don't need to stub Boom in handler-helper tests.

Avoid logging an error in listHandler test.