### PR TITLE
 Add enableMongooseRunValidators option (#85)

### DIFF
--- a/config.js
+++ b/config.js
@@ -253,6 +253,15 @@ config.enablePayloadValidation = true;
 config.enableResponseValidation = true;
 
 /**
+ * Mongoose validation options:
+ * - enableMongooseRunValidators: enables the runValidators option in Mongoose update calls
+ * <http://mongoosejs.com/docs/validation.html#update-validators>
+ * default: false
+ * @type {boolean}
+ */
+config.enableMongooseRunValidators = false;
+
+/**
  * Determines the hapi failAction of each response. Options are:
  * - true: responses that fail validation will return a 500 error.
  * - false: responses that fail validation will just log the offense and send the response as-is.

--- a/tests/handler-helper.tests.js
+++ b/tests/handler-helper.tests.js
@@ -67,7 +67,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -110,7 +110,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -152,7 +152,7 @@ test('handler-helper.listHandler', function (t) {
           var sandbox = sinon.sandbox.create();
           var Log = logger.bind("handler-helper");
           var server = sandbox.spy();
-          var countSpy = sandbox.spy()
+          var countSpy = sandbox.spy();
           var queryHelperStub = sandbox.stub(require('../utilities/query-helper'));
           queryHelperStub.createMongooseQuery = function () {
             return {
@@ -166,7 +166,7 @@ test('handler-helper.listHandler', function (t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -1012,7 +1012,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -1057,7 +1057,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -1105,7 +1105,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var preDeferred = Q.defer();
@@ -1174,7 +1174,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var deferred = Q.defer();
@@ -1244,7 +1244,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -1302,7 +1302,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var postDeferred = Q.defer();
@@ -1371,7 +1371,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var postDeferred = Q.defer();
@@ -1440,7 +1440,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var userModel = mongoose.model("user", userSchema);
@@ -1496,7 +1496,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -1539,7 +1539,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -1589,7 +1589,7 @@ test('handler-helper.findHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -1643,7 +1643,7 @@ test('handler-helper.findHandler', function(t) {
             './query-helper': queryHelperStub,
             'q': qStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -1692,7 +1692,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var preDeferred = Q.defer();
@@ -1747,7 +1747,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -1799,7 +1799,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -1845,7 +1845,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -1894,7 +1894,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          // sandbox.stub(Log, 'error').callsFake(function(){})
+          // sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var deferred = Q.defer();
@@ -1962,7 +1962,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -2024,7 +2024,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -2086,7 +2086,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2153,7 +2153,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2220,7 +2220,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2287,7 +2287,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2336,7 +2336,7 @@ test('handler-helper.createHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2388,7 +2388,7 @@ test('handler-helper.createHandler', function(t) {
             './query-helper': queryHelperStub,
             'q': qStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -2433,7 +2433,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var preDeferred = Q.defer();
@@ -2486,7 +2486,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -2528,7 +2528,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var deferred = Q.defer();
@@ -2578,7 +2578,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -2619,7 +2619,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2668,7 +2668,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2717,7 +2717,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -2759,7 +2759,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2808,7 +2808,7 @@ test('handler-helper.deleteOneHandler', function(t) {
           var server = sandbox.spy();
           var handlerHelper = proxyquire('../utilities/handler-helper', {
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -2861,7 +2861,7 @@ test('handler-helper.deleteOneHandler', function(t) {
             'q': qStub
           });
 
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -2914,7 +2914,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var preDeferred = Q.defer();
@@ -2969,7 +2969,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -3017,7 +3017,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -3064,7 +3064,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -3109,7 +3109,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           var deferred = Q.defer();
@@ -3168,7 +3168,7 @@ test('handler-helper.updateHandler', function(t) {
             './query-helper': queryHelperStub,
             './error-helper': errorHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -3217,7 +3217,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -3274,7 +3274,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -3331,7 +3331,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -3374,7 +3374,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -3417,7 +3417,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -3466,7 +3466,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             './query-helper': queryHelperStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
           userSchema.statics = {
@@ -3518,7 +3518,7 @@ test('handler-helper.updateHandler', function(t) {
           var handlerHelper = proxyquire('../utilities/handler-helper', {
             'q': qStub
           });
-          sandbox.stub(Log, 'error').callsFake(function(){})
+          sandbox.stub(Log, 'error').callsFake(function(){});
 
           var userSchema = new mongoose.Schema({});
 
@@ -3563,7 +3563,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //       });
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3611,7 +3611,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3661,7 +3661,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3714,7 +3714,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3765,7 +3765,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3816,7 +3816,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3871,7 +3871,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //       });
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3919,7 +3919,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("removeAssociation", removeAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -3969,7 +3969,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("removeAssociation", removeAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4022,7 +4022,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("removeAssociation", removeAssociation);
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4073,7 +4073,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4124,7 +4124,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4179,7 +4179,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //       });
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4226,7 +4226,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4279,7 +4279,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4333,7 +4333,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("setAssociation", setAssociation);
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4385,7 +4385,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4437,7 +4437,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4493,7 +4493,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //       });
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4549,7 +4549,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = proxyquire('../utilities/handler-helper', {
 //         './query-helper': queryHelperStub,
 //       });
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4612,7 +4612,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("QueryHelper", queryHelperStub);
 //       handlerHelper.__set__("list", handlerSpy2);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4687,7 +4687,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("QueryHelper", queryHelperStub);
 //       handlerHelper.__set__("list", handlerSpy2);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4763,7 +4763,7 @@ test('handler-helper.updateHandler', function(t) {
 //       handlerHelper.__set__("QueryHelper", queryHelperStub);
 //       handlerHelper.__set__("list", handlerSpy2);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4826,7 +4826,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       handlerHelper.__set__("Boom", boomStub);
 //       handlerHelper = handlerHelper(mongoose, server);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -4891,7 +4891,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       var setAssociation = handlerHelper.__get__("setAssociation");
-//       // sandbox.stub(Log, 'error').callsFake(function(){})
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -4950,7 +4950,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var deferredSpy = { resolve: sandbox.spy(function(){ deferred.resolve() }) };
 //       Qstub.defer = function(){ return deferredSpy };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error').callsFake(function(){})
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5024,7 +5024,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error').callsFake(function(){})
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5113,7 +5113,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5202,7 +5202,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error').callsFake(function(){})
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5287,7 +5287,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error').callsFake(function(){})
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5372,7 +5372,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var server = sandbox.spy();
 //       var handlerHelper = rewire('../utilities/handler-helper');
 //       var removeAssociation = handlerHelper.__get__("removeAssociation");
-//       // sandbox.stub(Log, 'error').callsFake(function(){})
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //
@@ -5431,7 +5431,7 @@ test('handler-helper.updateHandler', function(t) {
 //       var deferredSpy = { resolve: sandbox.spy(function(){ deferred.resolve() }) };
 //       Qstub.defer = function(){ return deferredSpy };
 //       handlerHelper.__set__("Q", Qstub);
-//       sandbox.stub(Log, 'error').callsFake(function(){})
+//       sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5517,7 +5517,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error').callsFake(function(){})
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5604,7 +5604,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error').callsFake(function(){})
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {
@@ -5689,7 +5689,7 @@ test('handler-helper.updateHandler', function(t) {
 //       Qstub.defer = function(){ return deferredSpy };
 //       Qstub.all = function(){ return Q.when() };
 //       handlerHelper.__set__("Q", Qstub);
-//       // sandbox.stub(Log, 'error').callsFake(function(){})
+//       // sandbox.stub(Log, 'error').callsFake(function(){});
 //
 //       var userSchema = new mongoose.Schema({});
 //       userSchema.statics = {

--- a/utilities/handler-helper.js
+++ b/utilities/handler-helper.js
@@ -586,7 +586,7 @@ function _updateHandler(model, _id, request, Log) {
           }
 
           //TODO: support eventLogs and log all property updates in one document rather than one document per property update
-          return model.findByIdAndUpdate(_id, payload)
+          return model.findByIdAndUpdate(_id, payload, { runValidators: config.enableMongooseRunValidators })
               .then(function (result) {
                 if (result) {
                   //TODO: log all updated/added associations
@@ -726,7 +726,7 @@ function _deleteOneHandler(model, _id, hardDelete, request, Log) {
                 payload.deletedBy = deletedBy;
               }
             }
-            promise = model.findByIdAndUpdate(_id, payload, {new: true});
+            promise = model.findByIdAndUpdate(_id, payload, { new: true, runValidators: config.enableMongooseRunValidators });
           }
           else {
             promise = model.findByIdAndRemove(_id);
@@ -1573,7 +1573,7 @@ function _setAssociation(ownerModel, ownerObject, childModel, childId, associati
               payload[ownerModel.modelName] = ownerObject._id;
               payload[childModel.modelName] = childObject._id;
 
-              promise = linkingModel.findOneAndUpdate(query, payload, { new: true, upsert: true });
+              promise = linkingModel.findOneAndUpdate(query, payload, { new: true, upsert: true, runValidators: config.enableMongooseRunValidators });
             }
             else {
               payload[childModel.modelName] = childObject._id;
@@ -1632,7 +1632,10 @@ function _setAssociation(ownerModel, ownerObject, childModel, childId, associati
                 childObject[childAssociationName][duplicateIndex] = payload;
               }
 
-              promise = Q.all([ownerModel.findByIdAndUpdate(ownerObject._id, ownerObject), childModel.findByIdAndUpdate(childObject._id, childObject)]);
+              promise = Q.all([
+                ownerModel.findByIdAndUpdate(ownerObject._id, ownerObject, { runValidators: config.enableMongooseRunValidators }),
+                childModel.findByIdAndUpdate(childObject._id, childObject, { runValidators: config.enableMongooseRunValidators })
+              ]);
             }
 
           }
@@ -1649,7 +1652,7 @@ function _setAssociation(ownerModel, ownerObject, childModel, childId, associati
               ownerObject[associationName].push(childId);
             }
 
-            promise = Q.all([ownerModel.findByIdAndUpdate(ownerObject._id, ownerObject)]);
+            promise = Q.all([ownerModel.findByIdAndUpdate(ownerObject._id, ownerObject, { runValidators: config.enableMongooseRunValidators })]);
           }
           else {
             deferred.reject(new Error("Association type incorrectly defined."));
@@ -1757,7 +1760,10 @@ function _removeAssociation(ownerModel, ownerObject, childModel, childId, associ
                 childObject[childAssociationName].splice(index, 1);
               }
 
-              promise = Q.all([ownerModel.findByIdAndUpdate(ownerObject._id, ownerObject), childModel.findByIdAndUpdate(childObject._id, childObject)]);
+              promise = Q.all([
+                ownerModel.findByIdAndUpdate(ownerObject._id, ownerObject, { runValidators: config.enableMongooseRunValidators }),
+                childModel.findByIdAndUpdate(childObject._id, childObject, { runValidators: config.enableMongooseRunValidators })
+              ]);
             }
           }
           else if (associationType === "_MANY") {//EXPL: remove reference from owner model
@@ -1773,7 +1779,7 @@ function _removeAssociation(ownerModel, ownerObject, childModel, childId, associ
               ownerObject[associationName].splice(index, 1);
             }
 
-            promise = Q.all([ownerModel.findByIdAndUpdate(ownerObject._id, ownerObject)]);
+            promise = Q.all([ownerModel.findByIdAndUpdate(ownerObject._id, ownerObject, { runValidators: config.enableMongooseRunValidators })]);
           }
           else {
             deferred.reject(new Error("Association type incorrectly defined."));


### PR DESCRIPTION
Set to true to enable the runValidators option in Mongoose update calls within the handler helpers.

Also, add missing semicolons in tests.