### PR TITLE
Upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -631,9 +631,9 @@
       }
     },
     "decache": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/decache/-/decache-4.1.0.tgz",
-      "integrity": "sha1-IDfV7fdW3aIwyFAjZZ58PR1uAQU=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.4.0.tgz",
+      "integrity": "sha1-b232uF1+fEQQqTL/wmSJt46azRM=",
       "dev": true,
       "requires": {
         "callsite": "1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hapi",
-  "version": "0.40.0",
+  "version": "0.43.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -67,6 +67,14 @@
         "hoek": "4.2.0"
       }
     },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -79,6 +87,11 @@
       "requires": {
         "color-convert": "1.9.0"
       }
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
     },
     "archy": {
       "version": "1.0.0",
@@ -105,6 +118,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-differ": {
       "version": "1.0.0",
@@ -142,6 +160,11 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async": {
       "version": "1.5.2",
@@ -248,7 +271,7 @@
       "resolved": "https://registry.npmjs.org/blue-tape/-/blue-tape-1.0.0.tgz",
       "integrity": "sha1-dYHQTAc5XJXEJrLtbR7bRUp2uSs=",
       "requires": {
-        "tape": "4.8.0"
+        "tape": "4.9.0"
       }
     },
     "bluebird": {
@@ -322,6 +345,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
       "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
+      "dev": true,
       "requires": {
         "cssmin": "0.3.2",
         "jsmin": "1.0.1",
@@ -338,7 +362,8 @@
         "uglify-js": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-          "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0="
+          "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
+          "dev": true
         }
       }
     },
@@ -356,24 +381,11 @@
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "requires": {
-        "callsites": "0.2.0"
-      }
-    },
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
-    },
-    "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
     "camelcase": {
       "version": "1.2.1",
@@ -487,7 +499,8 @@
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.5",
@@ -581,12 +594,19 @@
     "cssmin": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
-      "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0="
+      "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0=",
+      "dev": true
     },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
+    },
+    "dargs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+      "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -627,8 +647,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress": {
       "version": "4.2.0",
@@ -766,7 +785,8 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.1",
@@ -810,9 +830,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
-      "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+      "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.1",
@@ -846,6 +866,11 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
+    "events-to-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
+    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -875,6 +900,25 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -892,7 +936,8 @@
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
     },
     "fancy-log": {
       "version": "1.3.0",
@@ -967,6 +1012,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
       "requires": {
         "is-object": "1.0.1",
         "merge-descriptors": "1.0.1"
@@ -1084,6 +1130,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
       "requires": {
         "samsam": "1.2.1"
       }
@@ -1414,12 +1461,15 @@
       "integrity": "sha1-CCMTVIaDrQqwXUMNelYzMNTmE3A="
     },
     "gulp-tape": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/gulp-tape/-/gulp-tape-0.0.9.tgz",
-      "integrity": "sha1-lZZx+YwuGzmhBrs4LEDi37R4nTI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-tape/-/gulp-tape-1.0.0.tgz",
+      "integrity": "sha512-4pE3xGI4uzhKkLO9m3hmkLpNP/YCjiQAcf6j31uczU1S+cHqg2pgMadXBUf/H6XDgv+ZxK0ZGmvHU8dVE7DUQA==",
       "requires": {
-        "gulp-util": "3.0.8",
-        "require-uncached": "1.0.3",
+        "dargs": "5.1.0",
+        "nyc": "11.8.0",
+        "plugin-error": "1.0.1",
+        "tap-parser": "7.0.0",
+        "tape": "4.9.0",
         "through2": "2.0.3"
       }
     },
@@ -1764,7 +1814,8 @@
     "is": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
-      "integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI="
+      "integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI=",
+      "dev": true
     },
     "is-absolute": {
       "version": "0.2.6",
@@ -1852,7 +1903,8 @@
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -1963,7 +2015,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "items": {
       "version": "2.1.1",
@@ -2005,7 +2058,8 @@
     "jsmin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
-      "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw="
+      "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw=",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2086,7 +2140,8 @@
     "just-extend": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
-      "integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8="
+      "integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8=",
+      "dev": true
     },
     "jwt-simple": {
       "version": "0.5.1",
@@ -2097,6 +2152,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
       "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
+      "dev": true,
       "requires": {
         "js-yaml": "0.3.7",
         "moo-server": "1.3.0",
@@ -2107,7 +2163,8 @@
         "js-yaml": {
           "version": "0.3.7",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
-          "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I="
+          "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I=",
+          "dev": true
         }
       }
     },
@@ -2331,7 +2388,8 @@
     "lolex": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.2.tgz",
-      "integrity": "sha1-JpS5U8nqTQE+W4v7qJHJkQJbJik="
+      "integrity": "sha1-JpS5U8nqTQE+W4v7qJHJkQJbJik=",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -2361,6 +2419,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
       "requires": {
         "tmpl": "1.0.4"
       }
@@ -2379,7 +2438,8 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
     },
     "micromatch": {
       "version": "2.3.11",
@@ -2436,6 +2496,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "minipass": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.1.tgz",
+      "integrity": "sha512-liT0Gjaz7OHXg2qsfefVFfryBE9uAsqVFWQ6wVf4KNMzI2edsrCDjdGDpTxRaykbxhSKHu/SDtRRcMEcCcTQ2g==",
+      "requires": {
+        "safe-buffer": "5.1.1",
+        "yallist": "3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -2503,7 +2579,8 @@
     "module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "mongodb": {
       "version": "2.2.31",
@@ -2717,7 +2794,8 @@
     "moo-server": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/moo-server/-/moo-server-1.3.0.tgz",
-      "integrity": "sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE="
+      "integrity": "sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE=",
+      "dev": true
     },
     "mpath": {
       "version": "0.3.0",
@@ -2797,7 +2875,8 @@
     "native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
     },
     "natives": {
       "version": "1.1.0",
@@ -2817,6 +2896,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.1.0.tgz",
       "integrity": "sha512-lIFidCxB0mJGyq1i33tLRNojtMoYX95EAI7WQEU+/ees0w6hvXZQHZ7WD130Tjeh5+YJAUVLfQ3k/s9EA8jj+w==",
+      "dev": true,
       "requires": {
         "formatio": "1.2.0",
         "just-extend": "1.1.22",
@@ -2828,7 +2908,8 @@
         "lolex": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
         }
       }
     },
@@ -2841,6 +2922,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.0.8.tgz",
       "integrity": "sha1-urBDefc4P0WHmQyd8Htqf2Xbdys=",
+      "dev": true,
       "requires": {
         "is": "0.2.7",
         "object-keys": "0.4.0"
@@ -2849,7 +2931,8 @@
         "object-keys": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "dev": true
         }
       }
     },
@@ -2857,6 +2940,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/node.flow/-/node.flow-1.2.3.tgz",
       "integrity": "sha1-4cRKgq7KjXi0WKd/s9xkLy66Jkk=",
+      "dev": true,
       "requires": {
         "node.extend": "1.0.8"
       }
@@ -2875,6 +2959,2309 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "nyc": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.8.0.tgz",
+      "integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
+      "requires": {
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.1",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-reports": "1.4.0",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.1.0",
+        "micromatch": "3.1.10",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "4.2.1",
+        "yargs": "11.1.0",
+        "yargs-parser": "8.1.0"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true
+        },
+        "atob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "2.5.6",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "cache-base": "1.0.1",
+            "class-utils": "0.3.6",
+            "component-emitter": "1.2.1",
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "mixin-deep": "1.3.1",
+            "pascalcase": "0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "collection-visit": "1.0.0",
+            "component-emitter": "1.2.1",
+            "get-value": "2.0.6",
+            "has-value": "1.0.0",
+            "isobject": "3.0.1",
+            "set-value": "2.0.0",
+            "to-object-path": "0.3.0",
+            "union-value": "1.0.0",
+            "unset-value": "1.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "requires": {
+            "arr-union": "3.1.0",
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "static-extend": "0.1.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "map-visit": "1.0.0",
+            "object-visit": "1.0.1"
+          }
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "2.5.6",
+          "bundled": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "4.1.3",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "4.1.3",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "map-cache": "0.2.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "1.0.0",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-odd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.10.1",
+          "bundled": true,
+          "requires": {
+            "babel-generator": "6.26.1",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "semver": "5.5.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.3",
+          "bundled": true,
+          "requires": {
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "handlebars": "4.0.11"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "bundled": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "object-visit": "1.0.1"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "for-in": "1.0.2",
+            "is-extendable": "1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "nanomatch": {
+          "version": "1.2.9",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-odd": "2.0.0",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "copy-descriptor": "0.1.1",
+            "define-property": "0.2.5",
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            }
+          }
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "1.2.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "1.1.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "3.0.2",
+            "safe-regex": "1.1.0"
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ret": "0.1.15"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "split-string": "3.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "base": "0.11.2",
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "map-cache": "0.2.2",
+            "source-map": "0.5.7",
+            "source-map-resolve": "0.5.1",
+            "use": "3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "snapdragon-util": "3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "atob": "2.1.1",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "requires": {
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "which": "1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "3.0.2"
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "0.2.5",
+            "object-copy": "0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "test-exclude": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "3.1.10",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "braces": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              }
+            }
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            }
+          }
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-union": "3.1.0",
+            "get-value": "2.0.6",
+            "is-extendable": "0.1.1",
+            "set-value": "0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "to-object-path": "0.3.0"
+              }
+            }
+          }
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-value": "0.3.1",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "get-value": "2.0.6",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "use": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true
+            },
+            "cliui": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "9.0.2",
+              "bundled": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true
+            }
+          }
+        }
+      }
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -2887,9 +5274,9 @@
       "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
     },
     "object-inspect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
+      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw=="
     },
     "object-keys": {
       "version": "1.0.11",
@@ -3071,6 +5458,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
       "requires": {
         "isarray": "0.0.1"
       }
@@ -3118,6 +5506,24 @@
       "dev": true,
       "requires": {
         "pinkie": "2.0.4"
+      }
+    },
+    "plugin-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "requires": {
+        "ansi-colors": "1.1.0",
+        "arr-diff": "4.0.0",
+        "arr-union": "3.1.0",
+        "extend-shallow": "3.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        }
       }
     },
     "podium": {
@@ -3170,12 +5576,14 @@
     "promised-io": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.5.tgz",
-      "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y="
+      "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y=",
+      "dev": true
     },
     "proxyquire": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
       "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
+      "dev": true,
       "requires": {
         "fill-keys": "1.0.2",
         "module-not-found-error": "1.0.1",
@@ -3185,7 +5593,8 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
         }
       }
     },
@@ -3214,7 +5623,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.0.tgz",
       "integrity": "sha1-+99wBLTSr/eS+YcZgbeieU9VWUc=",
-      "dev": true,
       "requires": {
         "decode-uri-component": "0.2.0",
         "object-assign": "4.1.1",
@@ -3224,8 +5632,7 @@
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         }
       }
     },
@@ -3411,15 +5818,6 @@
       "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
       "integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
-    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -3458,11 +5856,6 @@
         "global-modules": "0.2.3"
       }
     },
-    "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
-    },
     "resumer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
@@ -3474,7 +5867,8 @@
     "rewire": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz",
-      "integrity": "sha1-ZCfee3/u+n02QBUH62SlOFvFjcc="
+      "integrity": "sha1-ZCfee3/u+n02QBUH62SlOFvFjcc=",
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
@@ -3498,6 +5892,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/rmdir/-/rmdir-1.2.0.tgz",
       "integrity": "sha1-T+A1fLBhaMJY5z6WgJPcTooPMlM=",
+      "dev": true,
       "requires": {
         "node.flow": "1.2.3"
       }
@@ -3515,7 +5910,8 @@
     "samsam": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc="
+      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+      "dev": true
     },
     "seek-bzip": {
       "version": "1.0.5",
@@ -3565,6 +5961,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.3.0.tgz",
       "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
+      "dev": true,
       "requires": {
         "build": "0.1.4",
         "diff": "3.3.1",
@@ -3582,7 +5979,8 @@
     "sinon-test": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/sinon-test/-/sinon-test-2.1.1.tgz",
-      "integrity": "sha512-YGy8Z/hOvYJst7TrGZ8s8H64kpJTcou40yx6DRCUJNRi9c4NPrwGPZn00+tUUx0dCtsz+UX1Lv7/K0J/exd3DA=="
+      "integrity": "sha512-YGy8Z/hOvYJst7TrGZ8s8H64kpJTcou40yx6DRCUJNRi9c4NPrwGPZn00+tUUx0dCtsz+UX1Lv7/K0J/exd3DA==",
+      "dev": true
     },
     "sliced": {
       "version": "1.0.1",
@@ -3691,8 +6089,7 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
       "version": "1.0.2",
@@ -3711,7 +6108,7 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.8.2",
+        "es-abstract": "1.11.0",
         "function-bind": "1.1.1"
       }
     },
@@ -3874,10 +6271,20 @@
         }
       }
     },
+    "tap-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
+      "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+      "requires": {
+        "events-to-array": "1.1.2",
+        "js-yaml": "3.10.0",
+        "minipass": "2.3.1"
+      }
+    },
     "tape": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
+      "integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
       "requires": {
         "deep-equal": "1.0.1",
         "defined": "1.0.0",
@@ -3887,11 +6294,21 @@
         "has": "1.0.1",
         "inherits": "2.0.3",
         "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
+        "object-inspect": "1.5.0",
+        "resolve": "1.5.0",
         "resumer": "0.0.0",
         "string.prototype.trim": "1.1.2",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        }
       }
     },
     "tar-stream": {
@@ -3950,7 +6367,8 @@
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -4011,12 +6429,14 @@
     "timespan": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
-      "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk="
+      "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
+      "dev": true
     },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
     },
     "topo": {
       "version": "2.0.2",
@@ -4054,7 +6474,8 @@
     "type-detect": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo="
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -4235,6 +6656,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
       "requires": {
         "makeerror": "1.0.11"
       }
@@ -4257,6 +6679,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
       "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+      "dev": true,
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",
@@ -4269,7 +6692,8 @@
         "async": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true
         }
       }
     },
@@ -4305,7 +6729,8 @@
     "wrench": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
-      "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE="
+      "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE=",
+      "dev": true
     },
     "x256": {
       "version": "0.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha1-iHr1TO7lx/RDBGGXHsQAxh0JrLs=",
       "requires": {
         "boom": "5.2.0",
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "agent-base": {
@@ -64,7 +64,7 @@
       "integrity": "sha1-v4CqshFpjqePY+9efxE91dnokX8=",
       "requires": {
         "boom": "5.2.0",
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "ansi-colors": {
@@ -284,7 +284,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
       "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "brace-expansion": {
@@ -373,7 +373,7 @@
       "integrity": "sha1-33b19R7o3Ui4VqyEAPfmnm1zmcQ=",
       "requires": {
         "boom": "5.2.0",
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "call-me-maybe": {
@@ -405,7 +405,7 @@
       "integrity": "sha512-4fui5lELzqZ+9cnaAP/BcqXTH6LvWLBRtFhJ0I4FfgfXiSaZcf6k9m9dqOyChiTxNYtvLk7ZMYSf7ahMq3bf5A==",
       "requires": {
         "boom": "5.2.0",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "joi": "10.6.0"
       }
     },
@@ -414,7 +414,7 @@
       "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-2.0.4.tgz",
       "integrity": "sha1-Qz4lWQLK9UIz0ShkKcj03xToItU=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "center-align": {
@@ -1554,7 +1554,7 @@
         "catbox-memory": "2.0.4",
         "cryptiles": "3.1.2",
         "heavy": "4.0.4",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "iron": "4.0.5",
         "items": "2.1.1",
         "joi": "10.6.0",
@@ -1574,7 +1574,7 @@
         "boom": "5.2.0",
         "fast-safe-stringify": "1.2.0",
         "handlebars": "4.0.10",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "http-status": "1.0.1",
         "joi": "11.0.2",
         "json-schema-ref-parser": "3.3.1",
@@ -1594,7 +1594,7 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-11.0.2.tgz",
           "integrity": "sha512-VoWLK6UAF92nBmF/cZnkX/un3Rz8J3t+BDJ59Q1Etm1utJU000wRuhWLSkU3OcIM7+MA5A0hjClp6AWU0k8G2w==",
           "requires": {
-            "hoek": "4.2.0",
+            "hoek": "4.2.1",
             "isemail": "3.0.0",
             "items": "2.1.1",
             "topo": "2.0.2"
@@ -1660,7 +1660,7 @@
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "sntp": "2.0.2"
       },
       "dependencies": {
@@ -1670,7 +1670,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -1681,14 +1681,14 @@
       "integrity": "sha1-NskTNsAMz+hSyqTRUwhjNc0vAOk=",
       "requires": {
         "boom": "5.2.0",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "joi": "10.6.0"
       }
     },
     "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -1754,7 +1754,7 @@
       "requires": {
         "ammo": "2.0.4",
         "boom": "5.2.0",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "items": "2.1.1",
         "joi": "10.6.0",
         "lru-cache": "4.1.1"
@@ -1808,7 +1808,7 @@
       "requires": {
         "boom": "5.2.0",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "is": {
@@ -2028,7 +2028,7 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
       "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
       "requires": {
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "isemail": "2.2.1",
         "items": "2.1.1",
         "topo": "2.0.2"
@@ -2480,7 +2480,7 @@
       "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
       "integrity": "sha1-uRCQcq03jCty9qAQHEPd+ys2ZB8=",
       "requires": {
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "mime-db": "1.30.0"
       }
     },
@@ -2839,7 +2839,7 @@
       "integrity": "sha512-SoY8+g3CzJqNP50cikQ5VcNVDmHVlMOy79h5GMEBTavp/mx4q9QzAuHiBu0S9ejUtcH4eopnPVhXRxm5gf0x8A==",
       "requires": {
         "boom": "4.3.1",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "items": "2.1.1",
         "lodash": "4.17.4"
       },
@@ -2849,7 +2849,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -2888,7 +2888,7 @@
       "resolved": "https://registry.npmjs.org/nigel/-/nigel-2.0.2.tgz",
       "integrity": "sha1-k6GGb7DFLYc5CqdeKxYfS1x15bE=",
       "requires": {
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "vise": "2.0.2"
       }
     },
@@ -5483,7 +5483,7 @@
         "b64": "3.0.3",
         "boom": "5.2.0",
         "content": "3.0.6",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "nigel": "2.0.2"
       }
     },
@@ -5531,7 +5531,7 @@
       "resolved": "https://registry.npmjs.org/podium/-/podium-1.3.0.tgz",
       "integrity": "sha512-ZIujqk1pv8bRZNVxwwwq0BhXilZ2udycQT3Kp8ah3f3TcTmVg7ILJsv/oLf47gRa2qeiP584lNq+pfvS9U3aow==",
       "requires": {
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "items": "2.1.1",
         "joi": "10.6.0"
       }
@@ -5948,7 +5948,7 @@
       "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.2.tgz",
       "integrity": "sha1-Hlw/bysmZJrcQvfrNQIUpaApHWc=",
       "requires": {
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "joi": "10.6.0"
       }
     },
@@ -5993,7 +5993,7 @@
       "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "source-map": {
@@ -6060,7 +6060,7 @@
       "requires": {
         "boom": "5.2.0",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "iron": "4.0.5",
         "items": "2.1.1",
         "joi": "10.6.0"
@@ -6156,7 +6156,7 @@
       "requires": {
         "boom": "5.2.0",
         "content": "3.0.6",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "pez": "2.1.5",
         "wreck": "12.5.0"
       }
@@ -6443,7 +6443,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "tough-cookie": {
@@ -6628,7 +6628,7 @@
       "resolved": "https://registry.npmjs.org/vise/-/vise-2.0.2.tgz",
       "integrity": "sha1-awjo+0y3bjpQzW3Q7DczjoEaDTk=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "vision": {
@@ -6637,7 +6637,7 @@
       "integrity": "sha1-4bYSstLi8gMQoDkpD9SdUSSPgto=",
       "requires": {
         "boom": "4.3.1",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "items": "2.1.1",
         "joi": "10.6.0"
       },
@@ -6647,7 +6647,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -6723,7 +6723,7 @@
       "integrity": "sha512-O2wljTGaQhlhhNLrpTDCecBw/Oa4aeUZ77ql2bOudD/phlHRJDT7ksoz9nFOX7eyLDkCG/QT5eH4FGTA34CHNw==",
       "requires": {
         "boom": "5.2.0",
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "wrench": {

--- a/package.json
+++ b/package.json
@@ -41,13 +41,16 @@
   "homepage": "https://github.com/JKHeadley/rest-hapi#readme",
   "dependencies": {
     "bcryptjs": "latest",
+    "blue-tape": "^1.0.0",
     "boom": "^5.1.0",
     "chalk": "*",
     "extend": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-exit": "0.0.2",
+    "gulp-tape": "latest",
     "hapi": "^16.4.3",
     "hapi-swagger": "7.8.1",
+    "hoek": "^4.2.1",
     "inert": "^4.2.0",
     "joi": "^10.6.0",
     "joi-objectid": "^2.0.0",
@@ -59,14 +62,12 @@
     "mrhorse": "^2.3.1",
     "q": "^1.4.1",
     "qs": "^6.2.1",
+    "query-string": "^5.0.0",
     "require-all": "^2.1.0",
     "require-dir": "~0.3.2",
-    "vision": "^4.1.1",
     "tap-colorize": "latest",
     "tape": "latest",
-    "gulp-tape": "latest",
-    "blue-tape": "^1.0.0",
-    "query-string": "^5.0.0"
+    "vision": "^4.1.1"
   },
   "devDependencies": {
     "decache": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -69,12 +69,12 @@
     "query-string": "^5.0.0"
   },
   "devDependencies": {
-    "rewire": "^2.5.2",
-    "proxyquire": "^1.7.10",
-    "sinon": "^3.3.0",
-    "sinon-test": "^2.1.0",
+    "decache": "^4.4.0",
     "mockgoose": "^7.3.3",
-    "decache": "4.1.0",
-    "rmdir": "^1.2.0"
+    "proxyquire": "^1.7.10",
+    "rewire": "^2.5.2",
+    "rmdir": "^1.2.0",
+    "sinon": "^3.3.0",
+    "sinon-test": "^2.1.0"
   }
 }


### PR DESCRIPTION
- Updated package-lock.json by running `npm install`
- Updated decache to 4.4.0: fixes 'Maximum call stack size exceeded' error on node v8 in 4.1.0
- Updated hoek to 4.2.1: fixes security vulnerability in 4.2.0