### PR TITLE
bump minimatch to ^3.0.4 because of vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,7 +1794,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
         "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
+        "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",


### PR DESCRIPTION
https://nodesecurity.io/advisories/118