### PR TITLE
feat: Add option to disable swagger

### DIFF
--- a/rest-hapi.js
+++ b/rest-hapi.js
@@ -92,7 +92,9 @@ async function register(server, options) {
     }
   }
 
-  registerHapiSwagger(server, Log, config)
+  if (!config.disableSwagger) {
+    await registerHapiSwagger(server, Log, config)
+  }
 
   registerMrHorse(server, Log, config)
 


### PR DESCRIPTION
This is needed if the `/` route is going to be used for other purposes such as serving an UI in production