### PR TITLE
[🔧] Config : add no semicolon for in prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "semi": false
 }


### PR DESCRIPTION
I add new rule into the .prettierrc files. The rule is `semi: false` for skiping auto adding semicolon.