### PR TITLE
Get cached models by name

### DIFF
--- a/rest-hapi.js
+++ b/rest-hapi.js
@@ -92,6 +92,14 @@ async function register(server, options) {
     }
   }
 
+  server.method('getModel', modelName => {
+    if (typeof models[modelName] === 'undefined') {
+      throw new Error(`model ${modelName} does'nt exist!`)
+    }
+
+    return models[modelName]
+  })
+
   if (!config.disableSwagger) {
     await registerHapiSwagger(server, Log, config)
   }


### PR DESCRIPTION
Hi

I needed to access models generated, in other plugins. so I added a server method to get a model by its name.
I saw that we have `generateModels` function, but that uses only default options, not the ones I used when registered rest-hapi plugin on my server.

Anyway please check it out and let me know if it looks good
Have a nice day