### PR TITLE
Added windows support for loading Policies

### DIFF
--- a/rest-hapi.js
+++ b/rest-hapi.js
@@ -205,7 +205,7 @@ async function registerMrHorse(server, logger, config) {
       policyPath = config.policyPath
     } else {
       policyPath = __dirname.replace(
-        'node_modules/rest-hapi',
+        path.join('node_modules', 'rest-hapi'),
         config.policyPath
       )
     }


### PR DESCRIPTION
small but fixes #231 

"node_modules/rest-hapi" dose not exist in __dirname
do to windows \ in path.
changed path replacement to be resolved by `path.join`
this should work on all platforms.

This should also be considered if anyone are modifying the `config.policyPath` with `config.absolutePolicyPath = true` if they intend the project to work on different platforms