### PR TITLE
when soft delete is active amount of deleted documents is returned in `items.deleted`

### DIFF
--- a/docs/querying.md
+++ b/docs/querying.md
@@ -67,6 +67,7 @@ For any GET query that returns multiple documents, pagination data is returned a
     * begin - a number indicating what item number the results begin with.
     * end - a number indicating what item number the results end with.
     * total - a number indicating the total number of matching results.
+    * deleted - a number indicating the number of soft deleted in total of matching results if soft delete is activated.
 
 > **NOTE:** Pagination format borrowed from mongo-models [pagedFind](https://github.com/jedireza/mongo-models/blob/master/API.md#pagedfindfilter-fields-sort-limit-page-callback).
 

--- a/utilities/handler-helper.js
+++ b/utilities/handler-helper.js
@@ -171,6 +171,13 @@ async function _listHandler(model, request, Log) {
       Log
     ).lean()
     const count = await mongooseQuery.countDocuments()
+
+    // allsow getting soft deleted count
+    let isDeletedCount = 0
+    if (config.enableSoftDelete) {
+      isDeletedCount = await mongooseQuery.countDocuments({ isDeleted: true })
+    }
+
     mongooseQuery = QueryHelper.paginate(query, mongooseQuery, Log)
     let result = await mongooseQuery.exec('find')
 
@@ -235,6 +242,11 @@ async function _listHandler(model, request, Log) {
       begin: (query.$page || 1) * query.$limit - query.$limit + 1,
       end: (query.$page || 1) * query.$limit,
       total: count
+    }
+
+    // show softDeleted items amount
+    if (config.enableSoftDelete) {
+      items.deleted = isDeletedCount
     }
 
     pages.total = Math.ceil(count / query.$limit)


### PR DESCRIPTION
solving #235

Using the `countDocuments()` as `count` that being returned as `items.total` but with query `{ isDeleted: true }`. This is only run if `config.enableSoftDelete = true`. I cant exclude isDeleted items do to client caching of documents with redux I still need them to be able to remove them from my store. 

Another solution that would work for me could be to do a call where I only return deleted items and then do my "refresh of data call" but I feel like the client should know how many deleted documents that exists inside of the total amount if soft deletion is used.