### PR TITLE
Add allowList to routeOptions

### DIFF
--- a/docs/route-customization.md
+++ b/docs/route-customization.md
@@ -65,6 +65,7 @@ You can prevent CRUD endpoints from generating by setting the correct property t
 
 Property | Effect when false
 --- | --- 
+allowList    |      omits ``GET /path`` endpoint
 allowRead    |      omits ``GET /path`` and ``GET /path/{_id}`` endpoints
 allowCreate  |      omits ``POST /path`` endpoint
 allowUpdate  |      omits ``PUT /path/{_id}`` endpoint

--- a/utilities/model-generator.js
+++ b/utilities/model-generator.js
@@ -47,7 +47,7 @@ module.exports = function(mongoose, logger, config) {
         const ext = path.extname(file)
         if (ext === '.js') {
           const modelName = path.basename(file, '.js')
-          const schema = require(modelPath + '/' + modelName).default(mongoose)
+          const schema = require(modelPath + '/' + modelName)(mongoose)
 
           // EXPL: Add text index if enabled
           if (config.enableTextSearch) {

--- a/utilities/model-generator.js
+++ b/utilities/model-generator.js
@@ -47,7 +47,7 @@ module.exports = function(mongoose, logger, config) {
         const ext = path.extname(file)
         if (ext === '.js') {
           const modelName = path.basename(file, '.js')
-          const schema = require(modelPath + '/' + modelName)(mongoose)
+          const schema = require(modelPath + '/' + modelName).default(mongoose)
 
           // EXPL: Add text index if enabled
           if (config.enableTextSearch) {

--- a/utilities/rest-helper-factory.js
+++ b/utilities/rest-helper-factory.js
@@ -49,7 +49,9 @@ module.exports = function(logger, mongoose, server) {
         options = options || {}
 
         if (model.routeOptions.allowRead !== false) {
-          this.generateListEndpoint(server, model, options, Log)
+		  if (model.routeOptions.allowList !== false) {
+			  this.generateListEndpoint(server, model, options, Log)
+		  }
           this.generateFindEndpoint(server, model, options, Log)
         }
 


### PR DESCRIPTION
Simple pull-request to add an option to disallow list endpoint generation.
Useless for certain documents in a project of mine and can cause a potential attack point to overload the server.
Thought it would be nice to have a more granular control over this particular endpoint generation.