### PR TITLE
Add a config for ESM compatibility

### DIFF
--- a/config.js
+++ b/config.js
@@ -350,4 +350,11 @@ config.enableSwaggerHttps = false
  */
 config.swaggerHost = undefined
 
+/**
+ * If set to true, models will be loaded as esm modules (export default)
+ * - options: 'true', 'false' (default: 'false')
+ * @type {boolean}
+ */
+config.esm = false
+
 module.exports = config

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -487,3 +487,13 @@ config.enableSwaggerHttps = false
  */
 config.swaggerHost = undefined
 ```
+
+ ## esm
+```javascript
+/**
+ * If set to true, models will be loaded as esm modules (export default)
+ * - options: 'true', 'false' (default: 'false')
+ * @type {boolean}
+ */
+config.esm = false
+```

--- a/utilities/model-generator.js
+++ b/utilities/model-generator.js
@@ -47,7 +47,8 @@ module.exports = function(mongoose, logger, config) {
         const ext = path.extname(file)
         if (ext === '.js') {
           const modelName = path.basename(file, '.js')
-          const schema = require(modelPath + '/' + modelName)(mongoose)
+          const schemaPrecursor = require(modelPath + '/' + modelName)
+          const schema = (config.esm ? schemaPrecursor.default : schemaPrecursor)(mongoose)
 
           // EXPL: Add text index if enabled
           if (config.enableTextSearch) {

--- a/website/versioned_docs/version-2.0.x/configuration.md
+++ b/website/versioned_docs/version-2.0.x/configuration.md
@@ -486,3 +486,13 @@ config.enableSwaggerHttps = false
  */
 config.swaggerHost = undefined
 ```
+
+ ## esm
+```javascript
+/**
+ * If set to true, models will be loaded as esm modules (export default)
+ * - options: 'true', 'false' (default: 'false')
+ * @type {boolean}
+ */
+config.esm = false
+```


### PR DESCRIPTION
Simple PR to add a `config.esm` property to load models on the `.default` in the case that ESM is used